### PR TITLE
Added support for direct specification of battery APA value

### DIFF
--- a/Adafruit_LC709203F.cpp
+++ b/Adafruit_LC709203F.cpp
@@ -150,8 +150,9 @@ bool Adafruit_LC709203F::setPackSize(lc709203_adjustment_t apa) {
 }
 
 /*!
- *    @brief  Set battery adjustment pack application (APA) value, per LC709203F datasheet
- *    @param apa_value The 8-bit APA value to use for the attached battery
+ *    @brief  Set battery adjustment pack application (APA) value, 
+ *            per LC709203F datasheet
+ *    @param apa_value 8-bit APA value to use for the attached battery
  *    @return True on successful I2C write
  */
 bool Adafruit_LC709203F::setPackAPA(uint8_t apa_value) {

--- a/Adafruit_LC709203F.cpp
+++ b/Adafruit_LC709203F.cpp
@@ -150,6 +150,15 @@ bool Adafruit_LC709203F::setPackSize(lc709203_adjustment_t apa) {
 }
 
 /*!
+ *    @brief  Set battery adjustment pack application (APA) value, per LC709203F datasheet
+ *    @param apa_value The 8-bit APA value to use for the attached battery
+ *    @return True on successful I2C write
+ */
+bool Adafruit_LC709203F::setPackAPA(uint8_t apa_value) {
+  return writeWord(LC709203F_CMD_APA, (uint16_t)apa_value);
+}
+
+/*!
  *    @brief  Set the alarm pin to respond to an RSOC percentage level
  *    @param percent The threshold value, set to 0 to disable alarm
  *    @return True on successful I2C write

--- a/Adafruit_LC709203F.cpp
+++ b/Adafruit_LC709203F.cpp
@@ -150,8 +150,7 @@ bool Adafruit_LC709203F::setPackSize(lc709203_adjustment_t apa) {
 }
 
 /*!
- *    @brief  Set battery adjustment pack application (APA) value, 
- *            per LC709203F datasheet
+ *    @brief  Set battery APA value, per LC709203F datasheet
  *    @param apa_value 8-bit APA value to use for the attached battery
  *    @return True on successful I2C write
  */

--- a/Adafruit_LC709203F.h
+++ b/Adafruit_LC709203F.h
@@ -74,6 +74,7 @@ public:
 
   bool setPowerMode(lc709203_powermode_t t);
   bool setPackSize(lc709203_adjustment_t apa);
+  bool setPackAPA(uint8_t apa_value);
 
   uint16_t getICversion(void);
   float cellVoltage(void);


### PR DESCRIPTION
Added a new function allowing the battery pack APA value to be specified directly, rather than constraining it to a specific set of predefined values through the lc709203_adjustment_t enumeration.  This gives developers greater flexibility in providing the LC709203F with an APA value that more accurately reflects the size of the battery pack being used.  (The existing setPackSize() function requires picking an APA value that most closely matches the battery being used from among the small set offered in the enumeration.)  This does require determination of the proper APA value for any particular battery, which can be obtained through interpolation from the curve provided in the LC709203F datasheet.

This change should work on any platform.  It constrains the APA value supplied to an 8-bit unsigned integer, which more than accommodates values shown in the LC709203F datasheet.

I tested this change using two different sized batteries, attached to an Adafruit MagTag.  Values returned for battery voltage and percent charge seemed consistent with but slightly different from those returned from using setPackSize() with the nearest corresponding value from the enumeration.  Ideally more testing with a a greater variety of battery sizes and range of charge levels would be good, but I have limited batteries to test with.  (Sorry.)  I'll continue to test with what I have on hand.

